### PR TITLE
Select drone on starting the interface

### DIFF
--- a/Assets/Scripts/ROS Scripts/ROS Connections v2/ROSManager.cs
+++ b/Assets/Scripts/ROS Scripts/ROS Connections v2/ROSManager.cs
@@ -81,6 +81,9 @@ public class ROSManager : MonoBehaviour {
         {
             InstantiateDrone(rosDroneConnectionInput);
         }
+
+        success = true;
+        WorldProperties.SelectNextDrone();
     }
 
     /// <summary>


### PR DESCRIPTION
 select the first drone on initialization, init the flight manager by pressing 0, no more null reference errors.