### PR TITLE
Waypoint editing

### DIFF
--- a/Assets/GameObjects/drone_obj.prefab
+++ b/Assets/GameObjects/drone_obj.prefab
@@ -884,10 +884,11 @@ GameObject:
   - component: {fileID: 4064626513410216}
   - component: {fileID: 95997159724389742}
   - component: {fileID: 114575724737126230}
-  - component: {fileID: 114113094254671172}
   - component: {fileID: 54791174084844380}
   - component: {fileID: 135519695496822468}
   - component: {fileID: 114986770307215778}
+  - component: {fileID: 114568125012931094}
+  - component: {fileID: 114654833738737616}
   m_Layer: 0
   m_Name: drone_obj
   m_TagString: Finish
@@ -7684,7 +7685,7 @@ MonoBehaviour:
   m_DynamicPixelsPerUnit: 1
 --- !u!114 &114568125012931094
 MonoBehaviour:
-  m_ObjectHideFlags: 1
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1497704686498948}
@@ -7693,7 +7694,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7787ec4cc870bae4c9e65fbfa30a4364, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 1
 --- !u!114 &114575724737126230
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -7705,12 +7705,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ceae650947d4b244f88ade35c574bdf0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  selectedMeshRenderer: {fileID: 0}
   selectedMaterial: {fileID: 2100000, guid: 97c9345d2c577e543b55b547a33c4858, type: 2}
   deselectedMaterial: {fileID: 2100000, guid: 1fe7c2dc0eb2fb34b989fb4e05287a4d, type: 2}
+  droneSimulationManager: {fileID: 0}
   droneMenu: {fileID: 0}
 --- !u!114 &114654833738737616
 MonoBehaviour:
-  m_ObjectHideFlags: 1
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1497704686498948}
@@ -7838,7 +7840,6 @@ MonoBehaviour:
   droneNameText: {fileID: 114772238858130042}
   droneAuthorityText: {fileID: 114914900665587038}
   menuCanvas: {fileID: 1479252145062286}
-  droneSimulationManager: {fileID: 114113094254671172}
 --- !u!135 &135519695496822468
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/GameObjects/waypoint.prefab
+++ b/Assets/GameObjects/waypoint.prefab
@@ -31,7 +31,7 @@ GameObject:
   - component: {fileID: 114629310516917166}
   m_Layer: 0
   m_Name: waypoint
-  m_TagString: Untagged
+  m_TagString: waypoint
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -180,7 +180,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   disableWhenIdle: 1
-  touchHighlightColor: {r: 0.72794116, g: 0.9705882, b: 0.8501014, a: 0}
+  allowedNearTouchControllers: 0
   allowedTouchControllers: 0
   ignoredColliders:
   - {fileID: 0}
@@ -198,6 +198,8 @@ MonoBehaviour:
   pointerActivatesUseAction: 0
   useOverrideButton: 0
   allowedUseControllers: 0
+  objectHighlighter: {fileID: 0}
+  touchHighlightColor: {r: 0.72794116, g: 0.9705882, b: 0.8501014, a: 0}
   usingState: 0
 --- !u!120 &120057133663641978
 LineRenderer:

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -620,7 +620,7 @@ Transform:
   - {fileID: 79141382}
   - {fileID: 167235401}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &146794964
 MonoBehaviour:
@@ -980,7 +980,7 @@ Transform:
   - {fileID: 1076179635}
   - {fileID: 78194254}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &279732760
 GameObject:
@@ -2198,7 +2198,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &665289476
 GameObject:
@@ -2304,7 +2304,7 @@ Transform:
   m_LocalScale: {x: 0.1, y: 0.100000024, z: 0.1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 83.595, y: 0, z: 0}
 --- !u!4 &731156519 stripped
 Transform:
@@ -4251,7 +4251,7 @@ Transform:
   m_Children:
   - {fileID: 901874430}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!21 &1537848749
 Material:
@@ -4725,8 +4725,8 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 1699223318}
-  - component: {fileID: 1699223319}
   - component: {fileID: 1699223320}
+  - component: {fileID: 1699223319}
   m_Layer: 0
   m_Name: Controller
   m_TagString: Untagged
@@ -4749,7 +4749,7 @@ Transform:
   - {fileID: 934963557}
   - {fileID: 317661247}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1699223319
 MonoBehaviour:
@@ -4759,11 +4759,18 @@ MonoBehaviour:
   m_GameObject: {fileID: 1699223317}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7f3c930cb716449459c64c5dcdf81bcc, type: 3}
+  m_Script: {fileID: 11500000, guid: 3c106c261bb66f544b5c69678c3581d5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  LeftController: {fileID: 0}
-  RightController: {fileID: 0}
+  controllerInput: {fileID: 1699223320}
+  Pivot: {fileID: 78194253}
+  World: {fileID: 146794962}
+  minScale: 0.1
+  maxScale: 10
+  speed: 1
+  direction: 0
+  rotationalSpeed: 1
+  rotationalDirection: 0
 --- !u!114 &1699223320
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4772,16 +4779,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1699223317}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fce500faaffe7ac4a9135cb03c53891a, type: 3}
+  m_Script: {fileID: 11500000, guid: 7bd91a12c07040e4f8d9ef97e7cb6fee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controllerState: {fileID: 0}
-  World: {fileID: 0}
-  actualScale: {x: 0, y: 0, z: 0}
-  MinimumScale: 0
-  MaximumScale: 0
-  Speed: 0
-  RotationalSpeed: 0
+  LeftController: {fileID: 2053542333}
+  LeftUI: {fileID: 491234449}
+  RightController: {fileID: 1347866310}
+  RightUI: {fileID: 1197405025}
 --- !u!1 &1715641644
 GameObject:
   m_ObjectHideFlags: 0
@@ -4810,8 +4814,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 616584610}
-  m_RootOrder: 0
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4886,8 +4890,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: -148.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 2055936989}
-  m_RootOrder: 1
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4942,9 +4946,7 @@ GameObject:
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1699223318}
-  - component: {fileID: 1699223320}
-  - component: {fileID: 1699223319}
+  - component: {fileID: 1800353104}
   m_Layer: 0
   m_Name: Controller
   m_TagString: Untagged
@@ -4952,58 +4954,19 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1699223318
+--- !u!4 &1800353104
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1699223317}
+  m_GameObject: {fileID: 1800353103}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1347866314}
-  - {fileID: 2053542334}
-  - {fileID: 934963557}
-  - {fileID: 317661247}
+  m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1699223319
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1699223317}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3c106c261bb66f544b5c69678c3581d5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  controllerInput: {fileID: 1699223320}
-  Pivot: {fileID: 78194253}
-  World: {fileID: 146794962}
-  minScale: 0.1
-  maxScale: 10
-  speed: 1
-  direction: 0
-  rotationalSpeed: 1
-  rotationalDirection: 0
---- !u!114 &1699223320
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1699223317}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7bd91a12c07040e4f8d9ef97e7cb6fee, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LeftController: {fileID: 2053542333}
-  LeftUI: {fileID: 491234449}
-  RightController: {fileID: 1347866310}
-  RightUI: {fileID: 1197405025}
 --- !u!1 &1818637095
 GameObject:
   m_ObjectHideFlags: 0
@@ -5298,7 +5261,7 @@ Transform:
   - {fileID: 1026087570}
   - {fileID: 1672332644}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1 &1866386692
 GameObject:

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -2950,7 +2950,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1197405026}
   - component: {fileID: 1197405029}
-  - component: {fileID: 1197405028}
   - component: {fileID: 1197405027}
   m_Layer: 0
   m_Name: Right UI Sphere
@@ -2967,8 +2966,9 @@ Transform:
   m_GameObject: {fileID: 1197405025}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.0008, y: 0.0004, z: 0.1004}
-  m_LocalScale: {x: 0.0452365, y: 0.0452365, z: 0.0452365}
-  m_Children: []
+  m_LocalScale: {x: 0.06, y: 0.06, z: 0.06}
+  m_Children:
+  - {fileID: 1456301588}
   m_Father: {fileID: 242895470}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2979,14 +2979,14 @@ MeshRenderer:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1197405025}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
   m_DynamicOccludee: 1
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 57ba41bd165d02f40838dc20443a9dfc, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -3006,18 +3006,6 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!135 &1197405028
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1197405025}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &1197405029
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -3425,7 +3413,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 64e104da36bd3b04b90c6ae969ac66dc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  customColliderContainer: {fileID: 0}
+  customColliderContainer: {fileID: 1914987908}
 --- !u!114 &1347866316
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3479,7 +3467,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1347866310}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 65eb64f0f2fd6d64faddbcf5d7d3bdbb, type: 3}
   m_Name: 
@@ -3945,6 +3933,77 @@ MonoBehaviour:
   snapToNearestFloor: 1
   applyPlayareaParentOffset: 0
   customRaycast: {fileID: 0}
+--- !u!1 &1456301587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1456301588}
+  - component: {fileID: 1456301590}
+  - component: {fileID: 1456301589}
+  m_Layer: 0
+  m_Name: Waypoint Placement Visualizer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1456301588
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1456301587}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.18, y: 0.18, z: 0.18}
+  m_Children: []
+  m_Father: {fileID: 1197405026}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1456301589
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1456301587}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 48f79b58f9f4c6f49b5fe7617beff012, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1456301590
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1456301587}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1480599130
 GameObject:
   m_ObjectHideFlags: 0
@@ -5574,6 +5633,47 @@ MonoBehaviour:
   capsuleTopOffset: 0.2
   capsuleBottomOffset: 0.5
   capsuleRadius: 0.5
+--- !u!1 &1914987908
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1914987909}
+  - component: {fileID: 1914987910}
+  m_Layer: 0
+  m_Name: Right VRTK Touch Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1914987909
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1914987908}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.00080001354, y: 0.00040006638, z: 0.10039997}
+  m_LocalScale: {x: 0.04524, y: 0.04524, z: 0.04524}
+  m_Children: []
+  m_Father: {fileID: 242895470}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &1914987910
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1914987908}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.03
+  m_Center: {x: 0, y: 0, z: 0.1}
 --- !u!1 &1921522138
 GameObject:
   m_ObjectHideFlags: 0
@@ -5766,7 +5866,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2053542333}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 64e104da36bd3b04b90c6ae969ac66dc, type: 3}
   m_Name: 
@@ -5778,7 +5878,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2053542333}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 947b27445602ed640b885db7e667dfc1, type: 3}
   m_Name: 
@@ -5845,7 +5945,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2053542333}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 65eb64f0f2fd6d64faddbcf5d7d3bdbb, type: 3}
   m_Name: 

--- a/Assets/Scripts/Interaction Scripts/ControllerInput.cs
+++ b/Assets/Scripts/Interaction Scripts/ControllerInput.cs
@@ -279,7 +279,7 @@
         /// <returns>True if the right hand is currently grabbing an object.</returns>
 		public bool RightIsGrabbing()
 		{
-			return (RightController.GetComponent<VRTK_InteractGrab>().GetGrabbedObject()) ? true : false;
+			return (RightController.GetComponent<VRTK_InteractGrab>().GetGrabbedObject() != null) ? true : false;
 		}
 
 		/// <summary>

--- a/Assets/Scripts/Interaction Scripts/ControllerInput.cs
+++ b/Assets/Scripts/Interaction Scripts/ControllerInput.cs
@@ -75,6 +75,22 @@
 		}
 
 		/// <summary>
+		/// Whether the left hand is currently grabbing a waypoint.
+		/// </summary>
+        /// <returns>True if the left hand is currently grabbing a waypoint.</returns>
+		public bool LeftIsGrabbingWaypoint()
+		{
+			GameObject grabbed = LeftController.GetComponent<VRTK_InteractGrab>().GetGrabbedObject();
+			if (grabbed) {
+				if (grabbed.tag == "waypoint")
+				{
+					return true;
+				}	
+			}
+			return false;
+		}
+
+		/// <summary>
 		/// Whether the left trigger (index finger) is held down. 
 		/// </summary>
 		/// <returns>True if the left trigger is held down.</returns>
@@ -263,7 +279,23 @@
         /// <returns>True if the right hand is currently grabbing an object.</returns>
 		public bool RightIsGrabbing()
 		{
-			return (RightController.GetComponent<VRTK_InteractGrab>().GetGrabbedObject()) ? true : false;;
+			return (RightController.GetComponent<VRTK_InteractGrab>().GetGrabbedObject()) ? true : false;
+		}
+
+		/// <summary>
+		/// Whether the right hand is currently grabbing a waypoint.
+		/// </summary>
+        /// <returns>True if the right hand is currently grabbing a waypoint.</returns>
+		public bool RightIsGrabbingWaypoint()
+		{
+			GameObject grabbed = RightController.GetComponent<VRTK_InteractGrab>().GetGrabbedObject();
+			if (grabbed) {
+				if (grabbed.tag == "waypoint")
+				{
+					return true;
+				}
+			}
+			return false;
 		}
 
 		/// <summary>

--- a/Assets/Scripts/Interaction Scripts/ThirdPersonView.cs
+++ b/Assets/Scripts/Interaction Scripts/ThirdPersonView.cs
@@ -71,6 +71,11 @@
                 // If nothing is held down, default to the idle state. 
                 case ControllerState.IDLE:
                 {
+                    if (controllerInput.RightIsGrabbing())
+                    {
+                        controllerState = ControllerState.MOVING_WAYPOINT;
+                        Debug.Log("*********************GW*********************");
+                    } 
                     if (controllerInput.BothGrip())
                     {
                         controllerState = ControllerState.SCALING;
@@ -227,6 +232,7 @@
                 {
                     if (!controllerInput.RightA())
                     {
+                        ControllerState.IDLE;
                         Undo();
                         break;
                     }
@@ -237,7 +243,6 @@
                         /// TODO: make waypoint disappear
                         break;
                     }
-                    controllerState = ControllerState.IDLE;
                     break;
                 }
 
@@ -245,7 +250,9 @@
                 {
                     if (!controllerInput.RightB())
                     {
+                        ControllerState.IDLE;
                         Redo();
+                        break; 
                     }
                     if (controllerInput.RightGrip())
                     {
@@ -254,7 +261,6 @@
                         /// TODO: make waypoint disappear
                         break;
                     }
-                    controllerState = ControllerState.IDLE;
                     break;
                 }
 

--- a/Assets/Scripts/Interaction Scripts/ThirdPersonView.cs
+++ b/Assets/Scripts/Interaction Scripts/ThirdPersonView.cs
@@ -71,11 +71,6 @@
                 // If nothing is held down, default to the idle state. 
                 case ControllerState.IDLE:
                 {
-                    if (controllerInput.RightIsGrabbing())
-                    {
-                        controllerState = ControllerState.MOVING_WAYPOINT;
-                        Debug.Log("*********************GW*********************");
-                    } 
                     if (controllerInput.BothGrip())
                     {
                         controllerState = ControllerState.SCALING;
@@ -200,6 +195,12 @@
 
                 case ControllerState.PLACING_WAYPOINT:
                 {
+                    if (controllerInput.RightIsGrabbingWaypoint())
+                    {
+                        controllerState = ControllerState.MOVING_WAYPOINT;
+                        break; 
+                    }
+
                     if (controllerInput.RightGrip()) /// Cancel waypoint placement
                     {
                         /// TODO: stop showing line
@@ -217,7 +218,7 @@
                     }
                     else
                     {
-                        /// TODO: continue line showing
+                        /// TODO: continue line showing and slightly faded wp
                     }
                     break;
 
@@ -225,6 +226,12 @@
 
                 case ControllerState.MOVING_WAYPOINT:
                 {
+                    if (!controllerInput.RightIsGrabbingWaypoint())
+                    {
+                        controllerState = ControllerState.IDLE;
+                        controllerInput.EnableRightPointer();
+                        break;
+                    }
                     break;
                 }
 
@@ -232,7 +239,7 @@
                 {
                     if (!controllerInput.RightA())
                     {
-                        ControllerState.IDLE;
+                        controllerState = ControllerState.IDLE;
                         Undo();
                         break;
                     }
@@ -250,7 +257,7 @@
                 {
                     if (!controllerInput.RightB())
                     {
-                        ControllerState.IDLE;
+                        controllerState = ControllerState.IDLE;
                         Redo();
                         break; 
                     }

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -3,7 +3,7 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  serializedVersion: 3
+  serializedVersion: 7
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
@@ -12,9 +12,18 @@ PhysicsManager:
   m_DefaultSolverIterations: 7
   m_DefaultSolverVelocityIterations: 1
   m_QueriesHitBackfaces: 0
-  m_QueriesHitTriggers: 1
+  m_QueriesHitTriggers: 0
   m_EnableAdaptiveForce: 0
-  m_EnablePCM: 1
+  m_ClothInterCollisionDistance: 0
+  m_ClothInterCollisionStiffness: 0
+  m_ContactsGeneration: 1
   m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   m_AutoSimulation: 1
   m_AutoSyncTransforms: 1
+  m_ClothInterCollisionSettingsToggle: 0
+  m_ContactPairsMode: 0
+  m_BroadphaseType: 0
+  m_WorldBounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 250, y: 250, z: 250}
+  m_WorldSubdivisions: 8


### PR DESCRIPTION
Waypoint editing fully implemented. The logic can be found in ThirdPersonView.cs (MOVING_WAYPOINT state) and relies on the RightIsGrabbingWaypoint() helper in ControllerInput.cs

The way it works is very similar to ISAACS v1.

Changes in Main.unity:
- Made the Right UI Sphere transparent, and added to it an opaque child sphere, to better indicate the grabbing area (large transparent sphere) vs the area where the waypoint is going to be places (small opaque area)
- Made the Right UI Sphere collider (used by the VRTK Interact touch script to indicate when a waypoint is being touched) a separate GameObject from the Right UI sphere. This is because the Right UI Sphere is often enabled/disabled according to the Controller's State, but we want the collider to remain enabled.
- Deactivated unused VRTK scripts in LeftController and RightController.

Changes in DynamicsManager.asset
- The laser pointer now ignore trigger objects, such as the Right VRTK Touch Collider (ie. the former Right UI Sphere's collider). They are still blocked by non-trigger objects, such as the ground and the drones. This saves us from having to constantly enable/disable objects that should not be interfering with the laser pointers.

Changes in Waypoint prefab:
- Added tag, to let RightIsGrabbingWaypoint() in ControllerInput.cs decide if the grabbed object is a waypoint.